### PR TITLE
Functionality to make Posts appear in Specific Groups strictly

### DIFF
--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -39,11 +39,11 @@ groupsController.details = async function (req, res, next) {
         }
     }
     const groupName = await groups.getGroupNameByGroupSlug(req.params.slug);
-    console.log("GROUPNAME");
-    console.log(groupName);
+//    console.log("GROUPNAME");
+//    console.log(groupName);
     const filterWords = [groupName]
-    console.log("filterWords");
-    console.log(filterWords);
+//    console.log("filterWords");
+//    console.log(filterWords);
 
     if (!groupName) {
         return next();

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -39,6 +39,12 @@ groupsController.details = async function (req, res, next) {
         }
     }
     const groupName = await groups.getGroupNameByGroupSlug(req.params.slug);
+    console.log("GROUPNAME");
+    console.log(groupName);
+    const filterWords = [groupName]
+    console.log("filterWords");
+    console.log(filterWords);
+
     if (!groupName) {
         return next();
     }
@@ -66,7 +72,8 @@ groupsController.details = async function (req, res, next) {
             truncateUserList: true,
             userListCount: 20,
         }),
-        groups.getLatestMemberPosts(groupName, 10, req.uid),
+        //groups.getLatestMemberPosts(groupName, 10, req.uid),
+        groups.getLatestMemberPostsByGroup(groupName, 10, req.uid, filterWords),
     ]);
     if (!groupData) {
         return next();

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -72,8 +72,8 @@ groupsController.details = async function (req, res, next) {
             truncateUserList: true,
             userListCount: 20,
         }),
-        //groups.getLatestMemberPosts(groupName, 10, req.uid),
-        groups.getLatestMemberPostsByGroup(groupName, 10, req.uid, filterWords),
+        groups.getLatestMemberPosts(groupName, 10, req.uid),
+        //groups.getLatestMemberPostsByGroup(groupName, 10, req.uid, filterWords),
     ]);
     if (!groupData) {
         return next();

--- a/src/groups/posts.js
+++ b/src/groups/posts.js
@@ -12,8 +12,8 @@ module.exports = function (Groups) {
         }
 
         let groupNames = await Groups.getUserGroupMembership('groups:visible:createtime', [postData.uid]);
-        console.log("GROUPNAMES");
-        console.log(groupNames);
+//        console.log("GROUPNAMES");
+//        console.log(groupNames);
         groupNames = groupNames[0];
 
         // Only process those groups that have the cid in its memberPostCids setting (or no setting at all)
@@ -23,9 +23,8 @@ module.exports = function (Groups) {
             groupData[idx].memberPostCidsArray.includes(postData.cid)
         ));
 
-
-        console.log("GROUPNAMES AFTER FILTERING");
-        console.log(groupNames);
+//        console.log("GROUPNAMES AFTER FILTERING");
+//        console.log(groupNames);
 
         const keys = groupNames.map(groupName => `group:${groupName}:member:pids`);
         await db.sortedSetsAdd(keys, postData.timestamp, postData.pid);
@@ -48,7 +47,7 @@ module.exports = function (Groups) {
         return await posts.getPostSummaryByPids(pids, uid, { stripTags: false });
     };
 
-    //new function filter by name of group 
+    //new function filter by name of group
     Groups.getLatestMemberPostsByGroup = async function (groupName, max, uid, filterWords = []) {
         let pids = await db.getSortedSetRevRange(`group:${groupName}:member:pids`, 0, max - 1);
         pids = await privileges.posts.filter('topics:read', pids, uid);

--- a/src/groups/posts.js
+++ b/src/groups/posts.js
@@ -48,6 +48,7 @@ module.exports = function (Groups) {
         return await posts.getPostSummaryByPids(pids, uid, { stripTags: false });
     };
 
+    //new function filter by name of group 
     Groups.getLatestMemberPostsByGroup = async function (groupName, max, uid, filterWords = []) {
         let pids = await db.getSortedSetRevRange(`group:${groupName}:member:pids`, 0, max - 1);
         pids = await privileges.posts.filter('topics:read', pids, uid);

--- a/unit tests/unit_tests_filter_feature.js
+++ b/unit tests/unit_tests_filter_feature.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const Groups = require('../src/groups');
+const db = require('./mocks/databasemock');
+const privileges = require('../src/privileges');
+const posts = require('../src/posts');
+
+describe('Groups', () => {
+    describe('getLatestMemberPosts', () => {
+        it('should return posts filtered by given words', async () => {
+            // Mock the database and privileges calls
+            db.getSortedSetRevRange = jest.fn().mockResolvedValue(['pid1', 'pid2', 'pid3']);
+            privileges.posts.filter = jest.fn().mockResolvedValue(['pid1', 'pid2']);
+            posts.getPostSummaryByPids = jest.fn().mockResolvedValue([
+                { pid: 'pid1', content: 'This is a test post' },
+                { pid: 'pid2', content: 'Another test post' },
+            ]);
+
+            const result = await Groups.getLatestMemberPosts('testGroup', 10, 1, ['test']);
+
+            expect(result).toEqual([
+                { pid: 'pid1', content: 'This is a test post' },
+                { pid: 'pid2', content: 'Another test post' },
+            ]);
+        });
+
+        it('should return empty array if no posts match the filter words', async () => {
+            // Mock the database and privileges calls
+            db.getSortedSetRevRange = jest.fn().mockResolvedValue(['pid1', 'pid2', 'pid3']);
+            privileges.posts.filter = jest.fn().mockResolvedValue(['pid1', 'pid2']);
+            posts.getPostSummaryByPids = jest.fn().mockResolvedValue([
+                { pid: 'pid1', content: 'This is a test post' },
+                { pid: 'pid2', content: 'Another test post' },
+            ]);
+
+            const result = await Groups.getLatestMemberPosts('testGroup', 10, 1, ['nonexistentword']);
+
+            expect(result).toEqual([]);
+        });
+    });
+});


### PR DESCRIPTION
Implemented a way to make certain posts appear strictly in certain groups based on the presence of a group name in a post

Testing:
Create a group called "17-313" and create a post that mentions "17-313" and only the specific group will include the post (make sure to uncomment line 76 and comment out line 75 to see the functionality in controllers/group.js) Unit tests for the functionality in unit_tests_filter_feature.js file and download npm install --save-dev jest to use unit test